### PR TITLE
Update Zenodo link to always point to all version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/repolicy/csp-guru.svg?branch=master)](https://travis-ci.org/repolicy/csp-guru)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1318152.svg)](https://doi.org/10.5281/zenodo.1318152)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1318151.svg)](https://doi.org/10.5281/zenodo.1318151)
 
 # Welcome to csp.guru!
 


### PR DESCRIPTION
Using this link will always link to the newest/all version. The old link is a permalink to the 2016 version -- so we would need to update for each release, which we do not want.