### PR TITLE
Paper subpage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: python
-install: pip install goodtables
-script: goodtables csp-guru/datapackage.json
+install: pip install frictionless
+script: frictionless validate csp-guru/datapackage.json

--- a/_config.yml
+++ b/_config.yml
@@ -12,4 +12,5 @@ theme: minima
 header_pages:
     - data.md
     - metadata.md
+    - paper.md
     - about.md

--- a/paper.md
+++ b/paper.md
@@ -1,0 +1,60 @@
+---
+layout: page
+title: Paper and Analysis
+---
+
+# Publications and analysis using CSP.guru
+
+csp. guru has beed developed since 2016 by Johan Lilliestam and his lab. The following publications use the data. If you want to cloaborate on additional publications or have used csp.guru for another publication not listed here, please [get in touch](mailto:richard.thonig@iass-potsdam.de).
+
+## Peer-reviewed publications that produced a new version of CSP.guru and explain the data collection procedure.
+
+Lilliestam, J., L. Ollier, M. Labordena, S. Pfenninger and R. Thonig (2020). The near- to mid-term outlook for concentrating solar power: mostly cloudy, chance of sun, in: [Energy Sources, Part B: Economics, Planning, and Policy: 1-19](https://doi.org/10.1080/15567249.2020.1773580)
+
+Lilliestam, J. and R. Pitz-Paal (2018). Concentrating solar power for less than USD 0.07 per kWh: finally the breakthrough?, in: [Renewable Energy Focus 26: 17-21](https://doi.org/10.1016/j.ref.2018.06.002)
+
+Lilliestam, J., Labordena, M., Patt, A., & Pfenninger, S. (2017). Empirically observed learning rates for concentrating solar power and their responses to regime change. [Nature Energy, 2, 17094.]( https://doi.org/10.1038/nenergy.2017.94)
+
+
+
+## Other peer-reviewed publications
+Kiefer, C. P. and P. del Río (2020). Analysing the barriers and drivers to concentrating solar power in the European Union. Policy implications, in: [Journal of Cleaner Production 251: 119400](https://doi.org/10.1016/j.jclepro.2019.119400).
+
+Gosens, J., C. Binz and R. Lema (2020). China’s role in the next phase of the energy transition: Contributions to global niche formation in the Concentrated Solar Power sector, in: [Environmental Innovation and Societal Transitions 34: 61-75](https://doi.org/10.1016/j.eist.2019.12.004)
+
+Schöniger, F., Thonig, R., Resch, G., & Lilliestam, J. (2020). Making the sun shine at night: comparing concentrating solar power and photovoltaics with storage. [Energy Sources, Part B: Economics, Planning, and Policy](https://doi.org/10.1080/15567249.2020.1843565)
+
+Aseri, T. K., C. Sharma and T. C. Kandpal (2020). Estimating capital cost of parabolic trough collector based concentrating solar power plants for financial appraisal: Approaches and a case study for India, in: [Renewable Energy 156: 1117-1131](https://doi.org/10.1016/j.renene.2020.04.138).
+
+del Río, P. and P. Mir-Artigues (2019). Designing auctions for concentrating solar power, in: [Energy for Sustainable Development 48: 67-81](https://doi.org/10.1016/j.esd.2018.10.005).
+
+Lilliestam, J., L. Ollier and S. Pfenninger (2019). "The dragon awakens: Will China save or conquer concentrating solar power?" [AIP Conference Proceedings 2126(1): 130006](https://aip.scitation.org/doi/abs/10.1063/1.5117648).
+
+Rea, J. E., C. J. Oshman, A. Singh, J. Alleman, G. Buchholz, P. A. Parilla, J. M. Adamczyk, H.-N. Fujishin, B. R. Ortiz, T. Braden, E. Bensen, R. T. Bell, N. P. Siegel, D. S. Ginley and E. S. Toberer (2019). "Prototype latent heat storage system with aluminum-silicon as a phase change material and a Stirling engine for electricity generation." [Energy Conversion and Management 199: 111992](https://doi.org/10.1016/j.enconman.2019.111992)
+
+Lilliestam, J., T. Barradi, N. Caldés, M. Gomez, S. Hanger, J. Kern, N. Komendantova, M. Mehos, W. M. Hong, Z. Wang and A. Patt (2018). Policies to keep and expand the option of concentrating solar power for dispatchable renewable electricity, in: [Energy Policy 116: 193-19](https://doi.org/10.1016/j.enpol.2018.02.014)
+
+Rea, J. E., C. J. Oshman, M. L. Olsen, C. L. Hardin, G. C. Glatzmaier, N. P. Siegel, P. A. Parilla, D. S. Ginley and E. S. Toberer (2018). Performance modeling and techno-economic analysis of a modular concentrated solar power tower with latent heat storage, in: [Applied Energy 217: 143-152](https://doi.org/10.1016/j.apenergy.2018.02.067).
+
+## Reports:
+The Horizon 2020 project [MUSTEC](www.mustec.eu) used data from CSP guru for multiple of its reports. Examples include:
+
+Resch, G., Schöniger, F., Kleinschmitt, C., Franke, K., Sensfuß, F., Thonig, R., and Lilliestam, J. (2020): [Market uptake of concentrating solar power in Europe: model-based analysis of drivers and policy trade-offs](https://www.mustec.eu/node/130). Deliverable 8.2 of the Horizon2020 project MUSTEC, TU Wien, Vienna, Austria.
+
+Schöniger, F., Resch, G., Kleinschmitt, C., Franke, K., Sensfuß, F., Lilliestam, J., Thonig, R. (2020): [Pivotal decisions and key factors for robust CSP strategies](https://www.iass-potsdam.de/de/ergebnisse/publikationen/2020/pivotal-decisions-and-key-factors-robust-csp-strategies-deliverable). Deliverable 7.4 MUSTEC project, TU Wien, Wien.
+
+Lilliestam, J. (2018). [Wither CSP? - Taking stock of a decade of concentrating solar power expansion and development](https://mustec.eu/node/66). Zürich, Deliverable 4.2, MUSTEC project, ETH Zürich.
+
+## Books
+
+Mir-Artigues, P., P. del Río and N. Caldés (2019). The Economics and Policy of Concentrating Solar Power Generation, [Springer International Publishing](https://www.springer.com/gp/book/9783030119379).
+
+## Old versions of CSP.guru
+
+Johan Lilliestam, Richard Thonig, Alina Gilmanova, & Chuncheng Zang. (2020). Csp.guru - openCSP (Version 2020-01-01) [Data set]. Zenodo. [http://doi.org/10.5281/zenodo.3909229](http://doi.org/10.5281/zenodo.3909229)
+
+Johan Lilliestam, Mercè Labordena, Lana Ollier, Stefan Pfenninger, Richard Thonig, & Tim Tröndle. (2019). CSP.guru (Version 2019-09-01) [Data set]. Zenodo. [http://doi.org/10.5281/zenodo.3466625](http://doi.org/10.5281/zenodo.3466625)
+
+Johan Lilliestam, Mercè Labordena, Lana Ollier, Stefan Pfenninger, Richard Thonig, & Tim Tröndle. (2018). CSP.guru (Version 2018-05-14) [Data set]. Zenodo. [http://doi.org/10.5281/zenodo.1342716](http://doi.org/10.5281/zenodo.1342716)
+
+Johan Lilliestam, & Mercè Labordena. (2016). CSP.guru (Version 2016-08-30) [Data set]. https://doi.org/10.1038/nenergy.2017.94. Zenodo. [http://doi.org/10.5281/zenodo.1318152](http://doi.org/10.5281/zenodo.1318152)

--- a/paper.md
+++ b/paper.md
@@ -3,19 +3,15 @@ layout: page
 title: Paper and Analysis
 ---
 
-# Publications and analysis using CSP.guru
+CSP.guru has been developed since 2016 by Johan Lilliestam and his lab. The following publications use the data. If you want to collaborate on additional publications or have used csp.guru for another publication not listed here, please [get in touch](mailto:richard.thonig@iass-potsdam.de).
 
-csp. guru has beed developed since 2016 by Johan Lilliestam and his lab. The following publications use the data. If you want to cloaborate on additional publications or have used csp.guru for another publication not listed here, please [get in touch](mailto:richard.thonig@iass-potsdam.de).
-
-## Peer-reviewed publications that produced a new version of CSP.guru and explain the data collection procedure.
+## Peer-reviewed publications leading to new csp.guru versions
 
 Lilliestam, J., L. Ollier, M. Labordena, S. Pfenninger and R. Thonig (2020). The near- to mid-term outlook for concentrating solar power: mostly cloudy, chance of sun, in: [Energy Sources, Part B: Economics, Planning, and Policy: 1-19](https://doi.org/10.1080/15567249.2020.1773580)
 
 Lilliestam, J. and R. Pitz-Paal (2018). Concentrating solar power for less than USD 0.07 per kWh: finally the breakthrough?, in: [Renewable Energy Focus 26: 17-21](https://doi.org/10.1016/j.ref.2018.06.002)
 
 Lilliestam, J., Labordena, M., Patt, A., & Pfenninger, S. (2017). Empirically observed learning rates for concentrating solar power and their responses to regime change. [Nature Energy, 2, 17094.]( https://doi.org/10.1038/nenergy.2017.94)
-
-
 
 ## Other peer-reviewed publications
 Kiefer, C. P. and P. del Río (2020). Analysing the barriers and drivers to concentrating solar power in the European Union. Policy implications, in: [Journal of Cleaner Production 251: 119400](https://doi.org/10.1016/j.jclepro.2019.119400).


### PR DESCRIPTION
As an exercise in csp.guru website manipulation I  added a page that lists papers and reports that reference csp.guru and changed the  config to display it.